### PR TITLE
OME005: navigation, state-of-art and resolution cleanup

### DIFF
--- a/OME005/index.md
+++ b/OME005/index.md
@@ -260,6 +260,38 @@ Follow-up work could include:
   support in the TIFF container, and could be optional for the simple
   case without reduction in *z*
 
+### Outstanding questions
+
+- Do we need to store metadata to describe alignment offsets between
+  sub-resolution levels when the size difference between levels
+  results in pixels not aligned on pixel boundaries, for example with
+  non-power-of-two reductions? How is this handled by the existing
+  pyramid file formats? (Question from 2018 OME annual meeting in
+  Dundee.)
+
+### Sample files
+
+Simple scripts to convert existing file formats with sub-resolutions to
+TIFF and OME-TIFF files with SUBIFDS have been created for testing
+purposes:
+
+- [makepyramid-ndpi](makepyramid-ndpi)
+- [makepyramid-scn](makepyramid-scn)
+- [makepyramid-svs](makepyramid-svs)
+
+Of the three, `makepyramid-scn` generates the most compliant OME-TIFF
+files with the best tile sizes and compression types.  These will be
+used to test the TIFF and OME-TIFF support for sub-resolutions in
+Bio-Formats and OME Files prior to the creation of a writer which can
+generate the files directly.
+
+Note that the scripts require a copy of Bio-Formats `showinf`
+on the `PATH`.   They also require a copy of libtiff on
+`LD_LIBRARY_PATH` and `tiffinfo` and `tiffset` on the `PATH`. libtiff
+must be a release > 4.0.9 for BigTIFF SUBIFDS support in `tiffset`;
+at the time of writing this means building a copy from git.
+
+
 ## Bio-Formats and OME-Files API and implementation changes
 
 ### Existing sub-resolution API
@@ -504,35 +536,4 @@ Lastly, update `ImageConverter` to set the resolutions in
 to loop over each resolution as well as each series and transfer all
 the resolution levels.  The `imageconverter-noflat` and
 `ometiff-pyramid-writer` branches implement most of the needed logic.
-
-### Outstanding questions
-
-- Do we need to store metadata to describe alignment offsets between
-  sub-resolution levels when the size difference between levels
-  results in pixels not aligned on pixel boundaries, for example with
-  non-power-of-two reductions? How is this handled by the existing
-  pyramid file formats? (Question from 2018 OME annual meeting in
-  Dundee.)
-
-### Sample files
-
-Simple scripts to convert existing file formats with sub-resolutions to
-TIFF and OME-TIFF files with SUBIFDS have been created for testing
-purposes:
-
-- [makepyramid-ndpi](makepyramid-ndpi)
-- [makepyramid-scn](makepyramid-scn)
-- [makepyramid-svs](makepyramid-svs)
-
-Of the three, `makepyramid-scn` generates the most compliant OME-TIFF
-files with the best tile sizes and compression types.  These will be
-used to test the TIFF and OME-TIFF support for sub-resolutions in
-Bio-Formats and OME Files prior to the creation of a writer which can
-generate the files directly.
-
-Note that the scripts require a copy of Bio-Formats `showinf`
-on the `PATH`.   They also require a copy of libtiff on
-`LD_LIBRARY_PATH` and `tiffinfo` and `tiffset` on the `PATH`. libtiff
-must be a release > 4.0.9 for BigTIFF SUBIFDS support in `tiffset`;
-at the time of writing this means building a copy from git.
 

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -181,8 +181,9 @@ Multi-file OME-TIFF                   | No*  | Yes      | Yes      | Yes*†    
 
 § Accessible, but without any metadata to indicate the structure
 
+### Resolution
 
-We will implement strategy B or C in the short term.  In the longer
+We will implement strategy C in the short term. In the longer
 term, E would allow *z* reductions (or requiring HDF5 might avoid the
 need for any model changes).
 
@@ -303,6 +304,12 @@ on the `PATH`.   They also require a copy of libtiff on
 must be a release > 4.0.9 for BigTIFF SUBIFDS support in `tiffset`;
 at the time of writing this means building a copy from git.
 
+### Resolution
+
+From ome-model 6.0.0, the OME-TIFF file format specification includes support
+for multi-resolution images - see
+https://docs.openmicroscopy.org/ome-model/latest/ome-tiff/specification.html
+and https://www.openmicroscopy.org/2019/02/18/bio-formats-6-0-0.html.
 
 ## Bio-Formats and OME-Files API and implementation changes
 
@@ -549,3 +556,9 @@ to loop over each resolution as well as each series and transfer all
 the resolution levels.  The `imageconverter-noflat` and
 `ometiff-pyramid-writer` branches implement most of the needed logic.
 
+### Resolution
+
+The release of Bio-Formats 6.0.0 includes support for reading and writing
+multi-resolution OME-TIFF - see 
+https://forum.image.sc/t/release-of-bio-formats-6-0-0/23099 or
+https://www.openmicroscopy.org/2019/02/18/bio-formats-6-0-0.html.

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -1,4 +1,4 @@
-# TIFF and OME-TIFF sub-resolution support
+# OME-TIFF sub-resolution support
 
 ## Introduction
 

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -24,7 +24,7 @@ OME-TIFF in Bio-Formats and OME Files, which include:
   (Damir Sudar)
 
 This investigation included the review of existing specifications, samples
-and implementations of TIFF-based formats. In particul:
+and implementations of TIFF-based formats:
 
 - Adobe Pyramid TIFF ([specification](https://www.loc.gov/preservation/digital/formats/fdd/fdd000237.shtml))
 - Aperio SVS ([specification](https://web.archive.org/web/20120420105738/http://www.aperio.com/documents/api/Aperio_Digital_Slides_and_Third-party_data_interchange.pdf), [OpenSlide samples](http://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/))

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -1,6 +1,6 @@
 # TIFF and OME-TIFF sub-resolution support
 
-# Introduction
+## Introduction
 
 There have been several different proposals for images at different
 scales in the form of sub-resolutions (image “pyramids”) for TIFF and
@@ -31,6 +31,8 @@ This proposal will summarise the various possible approaches and their
 tradeoffs, including the practical implementations I have tested while
 evaluating them.
 
+## Storage
+
 There are several strategies we could employ for sub-resolutions:
 
 ![Strategies A, B and C](strategy-a-b-c.svg)
@@ -40,7 +42,7 @@ There are several strategies we could employ for sub-resolutions:
 ![Strategy E](strategy-e.svg)
 
 
-## A. Implicit ordering
+### A. Implicit ordering
 
 This is the approach taken by the existing Pyramid TIFF reader
 
@@ -63,7 +65,7 @@ exception that the sub-resolution level order is reversed, starting
 with the smallest sub-resolution and ending with the full resolution.
 It has the same pros and cons.
 
-## B. SubIFDs pointing to main IFDs
+### B. SubIFDs pointing to main IFDs
 
 Intermediate between (A) and (C).  The `SubIFDs` tag is used to indicate that other IFDs are sub-resolutions of this IFD.  The other IFDs are part of the main IFD list, like (A).
 
@@ -78,7 +80,7 @@ Cons:
 - Sub-resolutions are still part of the main IFD list
 - Unlikely to be supported by libtiff
 
-## C. SubIFDs pointing to separate IFDs
+### C. SubIFDs pointing to separate IFDs
 
 This is how sub-resolutions in TIFF are ideally supported.
 
@@ -98,7 +100,7 @@ Cons:
 - Sub-resolutions not visible to software which doesn’t handle `SubIFDs`
 
 
-## D. External metadata with implicit resolution order
+### D. External metadata with implicit resolution order
 
 Similar to (A), but instead of using the `SubIFDs` tag the resolution
 count is specified in the Image OME-XML metadata.
@@ -122,7 +124,7 @@ Cons:
 - Not compatible with OME-TIFF multi-file structures
 - Requires data model changes
 
-## E. External metadata with explicit resolution order
+### E. External metadata with explicit resolution order
 
 Similar to (A), but instead of using the SubIFD tag the
 sub-resolutions IFDs are specified in the Image OME-XML metadata
@@ -205,7 +207,7 @@ the addition of support for strategy E.  Strategy E will require full
 support in the data model for TiffData (or equivalent) elements for
 every resolution level.
 
-# TIFF and OME-TIFF file format changes
+## TIFF and OME-TIFF file format changes
 
 This is based largely on Damir Sudar’s suggestions
 
@@ -258,9 +260,9 @@ Follow-up work could include:
   support in the TIFF container, and could be optional for the simple
   case without reduction in *z*
 
-# Bio-Formats and OME-Files API and implementation changes
+## Bio-Formats and OME-Files API and implementation changes
 
-## Existing sub-resolution API
+### Existing sub-resolution API
 
 Implemented only for reading
 
@@ -285,7 +287,7 @@ The implementation in `FormatReader` maintains the current resolution
 level for the active series, and whether or not resolutions are
 flattened (which affects the behaviour of the "core index" methods).
 
-## Proposed sub-resolution writer API additions
+### Proposed sub-resolution writer API additions
 
 The writer implementation needs to keep track of the number of
 resolution levels in the current series, and the current resolution in
@@ -377,7 +379,7 @@ for clean integration of sub-resolution functionality into tools like
 Keeping it hidden avoid this, but at the cost of accessing it
 requiring hardcoding of writer-specific special cases.
 
-## Proposed sub-resolution reader changes
+### Proposed sub-resolution reader changes
 
 | MinimalTiffReader | Description
 | ----------------- | -----------------------------------------
@@ -399,7 +401,7 @@ required.  With the corresponding reader support, this would provide
 transparent support for reading, writing, and conversion of data files
 containing sub-resolution data.
 
-## Implementation of writing support
+### Implementation of writing support
 
 Writing can be broken down into these steps, which can be implemented in order:
 
@@ -503,7 +505,7 @@ to loop over each resolution as well as each series and transfer all
 the resolution levels.  The `imageconverter-noflat` and
 `ometiff-pyramid-writer` branches implement most of the needed logic.
 
-## Outstanding questions
+### Outstanding questions
 
 - Do we need to store metadata to describe alignment offsets between
   sub-resolution levels when the size difference between levels
@@ -512,7 +514,7 @@ the resolution levels.  The `imageconverter-noflat` and
   pyramid file formats? (Question from 2018 OME annual meeting in
   Dundee.)
 
-## Sample files
+### Sample files
 
 Simple scripts to convert existing file formats with sub-resolutions to
 TIFF and OME-TIFF files with SUBIFDS have been created for testing

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -23,17 +23,15 @@ OME-TIFF in Bio-Formats and OME Files, which include:
   pyramids](https://www.openmicroscopy.org/community/viewtopic.php?f=15&t=8433)
   (Damir Sudar)
 
-This investigation included the review of existing implementation of pyramids
-in TIFF including published specification, available samples and open
-implementations:
+This investigation included the review of existing specifications, samples
+and implementations of TIFF-based formats. In particul:
 
-| Format              | Specification                                                        | Reference Implementation     |
-|---------------------|----------------------------------------------------------------------|------------------------------|
-| Adobe Pyramid TIFF  | https://www.loc.gov/preservation/digital/formats/fdd/fdd000237.shtml | private                      |
-| Aperio SVS          | private                                                              | private                      |
-| Leica SCN           | private                                                              | private                      |
-| Tiled Pyramidal TIF | https://iipimage.sourceforge.io/documentation/images/                | http://vips.sourceforge.net/ |
-| ZIF                 | https://zif.photo/                                                   | private (libtiff-based)      |
+- Adobe Pyramid TIFF ([specification](https://www.loc.gov/preservation/digital/formats/fdd/fdd000237.shtml))
+- Aperio SVS ([specification](https://web.archive.org/web/20120420105738/http://www.aperio.com/documents/api/Aperio_Digital_Slides_and_Third-party_data_interchange.pdf), [OpenSlide samples](http://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/))
+- Leica SCN ([OpenSlide samples](http://openslide.cs.cmu.edu/download/openslide-testdata/Leica/))
+- Tiled Pyramidal TIF ([specification](https://iipimage.sourceforge.io/documentation/images/), [libvips implementation](https://github.com/libvips/libvips))
+- ZIF ([specification](https://zif.photo/))
+
 
 Alternative existing approaches include:
 

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -29,8 +29,8 @@ and implementations of TIFF-based formats:
 - Adobe Pyramid TIFF ([specification](https://www.loc.gov/preservation/digital/formats/fdd/fdd000237.shtml))
 - Aperio SVS ([specification](https://web.archive.org/web/20120420105738/http://www.aperio.com/documents/api/Aperio_Digital_Slides_and_Third-party_data_interchange.pdf), [OpenSlide samples](http://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/))
 - Leica SCN ([OpenSlide samples](http://openslide.cs.cmu.edu/download/openslide-testdata/Leica/))
+- Objective Pathology ZIF ([specification](https://zif.photo/))
 - Tiled Pyramidal TIF ([specification](https://iipimage.sourceforge.io/documentation/images/), [libvips implementation](https://github.com/libvips/libvips))
-- ZIF ([specification](https://zif.photo/))
 
 
 Alternative existing approaches include:

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -1,5 +1,12 @@
 # OME-TIFF sub-resolution support
 
+## Table of contents
+
+1. [Introduction](#introduction)
+2. [Storage](#storage)
+3. [TIFF and OME-TIFF file format changes](#format)
+3. [Bio-Formats and OME-Files API and implementation changes](#implementation)
+
 ## Introduction
 
 There have been several different proposals for images at different
@@ -220,7 +227,7 @@ the addition of support for strategy E.  Strategy E will require full
 support in the data model for TiffData (or equivalent) elements for
 every resolution level.
 
-## TIFF and OME-TIFF file format changes
+## TIFF and OME-TIFF file format changes <a name="format"></a>
 
 This is based largely on Damir Sudar’s suggestions
 
@@ -311,7 +318,7 @@ for multi-resolution images - see
 https://docs.openmicroscopy.org/ome-model/latest/ome-tiff/specification.html
 and https://www.openmicroscopy.org/2019/02/18/bio-formats-6-0-0.html.
 
-## Bio-Formats and OME-Files API and implementation changes
+## Bio-Formats and OME-Files API and implementation changes <a name="implementation"></a>
 
 ### Existing sub-resolution API
 

--- a/OME005/index.md
+++ b/OME005/index.md
@@ -16,6 +16,18 @@ OME-TIFF in Bio-Formats and OME Files, which include:
   pyramids](https://www.openmicroscopy.org/community/viewtopic.php?f=15&t=8433)
   (Damir Sudar)
 
+This investigation included the review of existing implementation of pyramids
+in TIFF including published specification, available samples and open
+implementations:
+
+| Format              | Specification                                                        | Reference Implementation     |
+|---------------------|----------------------------------------------------------------------|------------------------------|
+| Adobe Pyramid TIFF  | https://www.loc.gov/preservation/digital/formats/fdd/fdd000237.shtml | private                      |
+| Aperio SVS          | private                                                              | private                      |
+| Leica SCN           | private                                                              | private                      |
+| Tiled Pyramidal TIF | https://iipimage.sourceforge.io/documentation/images/                | http://vips.sourceforge.net/ |
+| ZIF                 | https://zif.photo/                                                   | private (libtiff-based)      |
+
 Alternative existing approaches include:
 
 - [GeoTIFF](http://www.cogeo.org/in-depth.html) and its


### PR DESCRIPTION
Primarily motivated by the discussion of https://forum.image.sc/t/software-for-whole-slide-image-wsi-analysis-with-api-to-add-deep-learning-models/28748 as well as various feedback, this PR tidies up the official proposal used for the pyramidal OME-TIFF extension by:

- restricting the title and the scope of the proposal to the OME-TIFF format
- improving the navigation by fixing headings, adding anchors and a table of content
- including a paragraph in the introduction with an explicit acknowledgement of all the TIFF-based pyramidal formats examined during the initial scoping phase and which served as inspirations for the proposal
- moving the sample files under the `Format` section
- adding a `Resolution` sub-section to each of the sections linking to the decisions and/or documentation/software releases
